### PR TITLE
accessible-pygments 0.0.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,7 @@ requirements:
     - hatch-fancy-pypi-readme
   run:
     - python
-    - pygments >= 1.5
-
+    - pygments >=1.5
 test:
   imports:
     - a11y_pygments.a11y_light

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,13 @@ source:
   sha256: 40918d3e6a2b619ad424cb91e556bd3bd8865443d9f22f1dcdf79e33c8046872
 
 build:
-  noarch: python
+  skip: true   #[py<39]
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
-    - python >=3.9
+    - python
     - pip
     - setuptools
     - pygments
@@ -25,7 +25,7 @@ requirements:
     - setuptools-scm
     - hatch-fancy-pypi-readme
   run:
-    - python >=3.9
+    - python
     - pygments
 
 test:
@@ -34,6 +34,10 @@ test:
     - a11y_pygments.a11y_dark
     - a11y_pygments.a11y_high_contrast_light
     - a11y_pygments.a11y_high_contrast_dark
+  commands:
+    - pip check
+  requires:
+    - pip
 
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools
     - hatchling
     - hatch-vcs
-    - setuptools-scm
+   
     - hatch-fancy-pypi-readme
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
     - hatchling
     - hatch-vcs
    

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,14 +19,13 @@ requirements:
     - python
     - pip
     - setuptools
-    - pygments
     - hatchling
     - hatch-vcs
     - setuptools-scm
     - hatch-fancy-pypi-readme
   run:
     - python
-    - pygments
+    - pygments >= 1.5
 
 test:
   imports:
@@ -49,7 +48,7 @@ about:
   description: |
     A collection of WCAG 2.1 conformant pygments styles
   dev_url: https://github.com/Quansight-Labs/accessible-pygments
-
+  doc_url: https://pypi.org/project/accessible-pygments/
 extra:
   recipe-maintainers:
     - carreau


### PR DESCRIPTION
> ## ☆ accessible-pygments 0.0.5  ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-6546) 
[Upstream](https://github.com/Quansight-Labs/accessible-pygments)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 
> * Added skip to `python` versions less than 3.9
> *  Updated `about` section